### PR TITLE
Move "Source" reference to its own line

### DIFF
--- a/engagement-handbook.md
+++ b/engagement-handbook.md
@@ -56,6 +56,7 @@ Limit mention of engagement groups to only Netdata team group
 - Address all the points of the users. Using bullet points works for everyone.
 - Make sure you acknowledge how they feel.
     - e.g “I understand that this is frustrating, but don’t worry, we are on top of it!”
+
 [Source](https://petros.blog/2020/11/13/words-matter/)
 
 ## Example for points (1,2)


### PR DESCRIPTION
Thanks again for referencing my blog post. I am humbled folks can can inspired by what I share.

The thinking behind this suggestion is to make it clear the inspiration and source is for the whole list, not just the quoted example. If I may suggest that of course 🙇‍♂️.